### PR TITLE
Document all functions with runnable rustdoc examples

### DIFF
--- a/src/bin/big_file.rs
+++ b/src/bin/big_file.rs
@@ -4,6 +4,24 @@ use rand::{Rng, TryRngCore};
 
 const SIZE: usize = 2 * 1024 * 1024 * 1024;
 
+/// Fills a 2&nbsp;GiB buffer with cryptographically secure random bytes and writes it to
+/// `big_file.txt` in the current working directory.
+///
+/// The function is intentionally minimal: it streams random data directly into a
+/// preallocated buffer before persisting it, providing a quick way to manufacture a
+/// large file for benchmarking the rest of the project.
+///
+/// # Examples
+///
+/// ```
+/// use rand::rngs::OsRng;
+/// use rand::RngCore;
+///
+/// // The real binary writes 2 GiB, but the technique scales to any size.
+/// let mut sample = vec![0u8; 32];
+/// OsRng.fill_bytes(&mut sample);
+/// assert!(sample.iter().any(|byte| *byte != 0));
+/// ```
 fn main() {
     let mut rng = rand::rngs::OsRng;
 

--- a/src/chunker/commit.rs
+++ b/src/chunker/commit.rs
@@ -12,6 +12,30 @@ use memmap2::Mmap;
 const MMAP_THRESHOLD: u64 = 10 * 1024 * 1024;
 
 impl Chunker {
+    /// Commits a file by chunking it, generating parity data, and building the
+    /// associated Merkle tree and manifest on disk.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::chunker::Chunker;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let sandbox = std::env::temp_dir().join(format!("blockframe_commit_{}", std::process::id()));
+    /// if sandbox.exists() {
+    ///     std::fs::remove_dir_all(&sandbox)?;
+    /// }
+    /// std::fs::create_dir_all(&sandbox)?;
+    /// std::fs::write(sandbox.join("sample.txt"), b"commit me")?;
+    /// let original = std::env::current_dir()?;
+    /// std::env::set_current_dir(&sandbox)?;
+    /// let chunker = Chunker::new().unwrap();
+    /// let committed = chunker.commit(std::path::Path::new("sample.txt"))?;
+    /// assert_eq!(committed.file_name, "sample.txt");
+    /// std::env::set_current_dir(original)?;
+    /// std::fs::remove_dir_all(sandbox)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn commit(&self, file_path: &Path) -> Result<ChunkedFile, std::io::Error> {
         // 1. Get file metadata (doesnt load file)
         let mut file = File::open(file_path)?;

--- a/src/chunker/helpers.rs
+++ b/src/chunker/helpers.rs
@@ -3,6 +3,22 @@ use crate::merkle_tree::MerkleTree;
 use super::Chunker;
 
 impl Chunker {
+    /// Hashes the data and parity shards belonging to a segment to produce the
+    /// Merkle root recorded in the manifest.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::chunker::Chunker;
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// let chunker = Chunker::new().unwrap();
+    /// let chunks = chunker.get_chunks(b"blockframe segment hashing")?;
+    /// let parity = chunker.generate_parity(&chunks, 6, 3)?;
+    /// let segment_hash = chunker.hash_segment(&chunks, &parity)?;
+    /// assert_eq!(segment_hash.len(), 64);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn hash_segment(
         &self,
         chunks: &[Vec<u8>],

--- a/src/chunker/io.rs
+++ b/src/chunker/io.rs
@@ -11,6 +11,28 @@ use serde_json::json;
 
 use crate::merkle_tree::MerkleTree;
 impl Chunker {
+    /// Reads all stored chunk files from the chunker's working directory while
+    /// ignoring the manifest.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::chunker::Chunker;
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// let sandbox = std::env::temp_dir().join(format!("blockframe_read_chunks_{}", std::process::id()));
+    /// if sandbox.exists() {
+    ///     std::fs::remove_dir_all(&sandbox)?;
+    /// }
+    /// std::fs::create_dir_all(&sandbox)?;
+    /// std::fs::write(sandbox.join("chunk_0.dat"), b"data")?;
+    /// let mut chunker = Chunker::new().unwrap();
+    /// chunker.file_dir = Some(sandbox.clone());
+    /// let chunks = chunker.read_chunks()?;
+    /// assert_eq!(chunks.len(), 1);
+    /// std::fs::remove_dir_all(sandbox)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn read_chunks(&self) -> Result<Vec<Vec<u8>>, std::io::Error> {
         let read_dir = fs::read_dir(&self.file_dir.as_ref().ok_or(std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -30,12 +52,60 @@ impl Chunker {
         Ok(chunks)
     }
 
+    /// Ensures the `archive_directory` exists relative to the current working
+    /// directory, creating it if necessary.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::chunker::Chunker;
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// let sandbox = std::env::temp_dir().join(format!("blockframe_check_archive_{}", std::process::id()));
+    /// if sandbox.exists() {
+    ///     std::fs::remove_dir_all(&sandbox)?;
+    /// }
+    /// std::fs::create_dir_all(&sandbox)?;
+    /// let original = std::env::current_dir()?;
+    /// std::env::set_current_dir(&sandbox)?;
+    /// let chunker = Chunker::new().unwrap();
+    /// chunker.check_for_archive_dir()?;
+    /// assert!(std::path::Path::new("archive_directory").exists());
+    /// std::env::set_current_dir(original)?;
+    /// std::fs::remove_dir_all(sandbox)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn check_for_archive_dir(&self) -> Result<(), std::io::Error> {
         Ok(if !Path::new("archive_directory").is_dir() {
             self.create_dir(Path::new("archive_directory"))?;
         })
     }
 
+    /// Writes both data and parity shards for a particular segment into the
+    /// archive directory structure.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::chunker::Chunker;
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// let sandbox = std::env::temp_dir().join(format!("blockframe_write_segment_{}", std::process::id()));
+    /// if sandbox.exists() {
+    ///     std::fs::remove_dir_all(&sandbox)?;
+    /// }
+    /// std::fs::create_dir_all(&sandbox)?;
+    /// let original = std::env::current_dir()?;
+    /// std::env::set_current_dir(&sandbox)?;
+    /// let chunker = Chunker::new().unwrap();
+    /// let chunks = vec![b"chunk".to_vec(); 6];
+    /// let parity = vec![b"parity".to_vec(); 3];
+    /// chunker.write_segment_chunks(0, &"file.txt".to_string(), &"hash".to_string(), &chunks, &parity)?;
+    /// assert!(std::path::Path::new("archive_directory/file.txt_hash/segments/segment_0/chunks").exists());
+    /// std::env::set_current_dir(original)?;
+    /// std::fs::remove_dir_all(sandbox)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn write_segment_chunks(
         &self,
         segment_index: usize,
@@ -62,6 +132,25 @@ impl Chunker {
         Ok(())
     }
 
+    /// Writes the supplied chunk buffers to disk within `chunks_dir`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::chunker::Chunker;
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// let chunker = Chunker::new().unwrap();
+    /// let sandbox = std::env::temp_dir().join(format!("blockframe_write_chunks_{}", std::process::id()));
+    /// if sandbox.exists() {
+    ///     std::fs::remove_dir_all(&sandbox)?;
+    /// }
+    /// std::fs::create_dir_all(&sandbox)?;
+    /// chunker.write_chunks(&sandbox, &[b"chunk".to_vec()])?;
+    /// assert!(sandbox.join("chunk_0.dat").exists());
+    /// std::fs::remove_dir_all(sandbox)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn write_chunks(
         &self,
         chunks_dir: &Path,
@@ -81,6 +170,34 @@ impl Chunker {
         Ok(())
     }
 
+    /// Writes parity buffers to disk within `parity_dir`.
+    ///
+    /// The helper is normally called by [`write_segment_chunks`](Self::write_segment_chunks);
+    /// the example demonstrates its effect by invoking the public method and
+    /// checking that parity files are created.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::chunker::Chunker;
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// let sandbox = std::env::temp_dir().join(format!("blockframe_write_parity_{}", std::process::id()));
+    /// if sandbox.exists() {
+    ///     std::fs::remove_dir_all(&sandbox)?;
+    /// }
+    /// std::fs::create_dir_all(&sandbox)?;
+    /// let original = std::env::current_dir()?;
+    /// std::env::set_current_dir(&sandbox)?;
+    /// let chunker = Chunker::new().unwrap();
+    /// let chunks = vec![b"chunk".to_vec(); 6];
+    /// let parity = vec![b"parity".to_vec(); 3];
+    /// chunker.write_segment_chunks(0, &"file.txt".to_string(), &"hash".to_string(), &chunks, &parity)?;
+    /// assert!(std::path::Path::new("archive_directory/file.txt_hash/segments/segment_0/parity/parity_0.dat").exists());
+    /// std::env::set_current_dir(original)?;
+    /// std::fs::remove_dir_all(sandbox)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_parity_chunks(
         &self,
         parity_dir: &Path,
@@ -98,6 +215,20 @@ impl Chunker {
         Ok(())
     }
 
+    /// Calculates the archive directory where a committed file's segments and
+    /// manifest will live.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::chunker::Chunker;
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// let chunker = Chunker::new().unwrap();
+    /// let dir = chunker.get_dir(&"example.txt".to_string(), &"hash".to_string())?;
+    /// assert!(dir.ends_with("example.txt_hash"));
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn get_dir(
         &self,
         file_name: &String,
@@ -108,6 +239,24 @@ impl Chunker {
         Ok(dir.to_path_buf())
     }
 
+    /// Creates a directory and returns whether the directory was newly created.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::chunker::Chunker;
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// let chunker = Chunker::new().unwrap();
+    /// let sandbox = std::env::temp_dir().join(format!("blockframe_create_dir_{}", std::process::id()));
+    /// if sandbox.exists() {
+    ///     std::fs::remove_dir_all(&sandbox)?;
+    /// }
+    /// assert!(chunker.create_dir(&sandbox)?);
+    /// assert!(!chunker.create_dir(&sandbox)?);
+    /// std::fs::remove_dir_all(sandbox)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn create_dir(&self, file_dir: &Path) -> Result<bool, std::io::Error> {
         if !file_dir.is_dir() {
             fs::create_dir_all(file_dir)?;
@@ -117,6 +266,28 @@ impl Chunker {
         }
     }
 
+    /// Writes the manifest metadata for a committed file, including the Merkle
+    /// tree description, to `file_dir`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::chunker::Chunker;
+    /// # use blockframe::merkle_tree::MerkleTree;
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// let chunker = Chunker::new().unwrap();
+    /// let sandbox = std::env::temp_dir().join(format!("blockframe_write_manifest_{}", std::process::id()));
+    /// if sandbox.exists() {
+    ///     std::fs::remove_dir_all(&sandbox)?;
+    /// }
+    /// std::fs::create_dir_all(&sandbox)?;
+    /// let tree = MerkleTree::new(vec![b"chunk".to_vec(), b"more".to_vec()])?;
+    /// chunker.write_manifest(&tree, &"hash".to_string(), &"file.txt".to_string(), 8, 6, 3, &sandbox)?;
+    /// assert!(sandbox.join("manifest.json").exists());
+    /// std::fs::remove_dir_all(sandbox)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn write_manifest(
         &self,
         merkle_tree: &MerkleTree,

--- a/src/chunker/mod.rs
+++ b/src/chunker/mod.rs
@@ -35,6 +35,17 @@ pub struct ChunkedFile {
     pub parity_shards: usize,
 }
 impl Chunker {
+    /// Creates a new [`Chunker`] instance with default shard counts suitable for
+    /// Reed-Solomon encoding.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::chunker::Chunker;
+    /// let chunker = Chunker::new().unwrap();
+    /// assert_eq!(chunker.data_shards, 6);
+    /// assert_eq!(chunker.parity_shards, 3);
+    /// ```
     pub fn new() -> Result<Self, String> {
         const DATA_SHARDS: usize = 6;
         const PARITY_SHARDS: usize = 3;

--- a/src/filestore/mod.rs
+++ b/src/filestore/mod.rs
@@ -2,18 +2,67 @@ use std::collections::HashMap;
 use std::fs::{self};
 use std::path::{Path, PathBuf};
 
+/// Lightweight wrapper around an archive directory that exposes helper
+/// functions for introspecting manifests on disk.
 pub struct FileStore {
     pub store_path: PathBuf,
 }
 
 impl FileStore {
-    /// Create a new FileStore at the given path
+    /// Creates a new [`FileStore`] rooted at `store_path`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::filestore::FileStore;
+    /// # use std::path::Path;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let sandbox = std::env::temp_dir().join(format!("blockframe_filestore_new_{}", std::process::id()));
+    /// if sandbox.exists() {
+    ///     std::fs::remove_dir_all(&sandbox)?;
+    /// }
+    /// std::fs::create_dir_all(&sandbox)?;
+    /// let store = FileStore::new(&sandbox)?;
+    /// assert_eq!(store.store_path, sandbox);
+    /// std::fs::remove_dir_all(store.store_path.clone())?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn new(store_path: &Path) -> Result<Self, std::io::Error> {
         Ok(FileStore {
             store_path: store_path.to_path_buf(),
         })
     }
 
+    /// Returns a vector of hash maps describing each archived file's manifest
+    /// metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::filestore::FileStore;
+    /// # use std::path::Path;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let sandbox = std::env::temp_dir().join(format!("blockframe_filestore_hashmap_{}", std::process::id()));
+    /// if sandbox.exists() {
+    ///     std::fs::remove_dir_all(&sandbox)?;
+    /// }
+    /// std::fs::create_dir_all(&sandbox)?;
+    /// let original = std::env::current_dir()?;
+    /// std::env::set_current_dir(&sandbox)?;
+    /// let archive = Path::new("archive_directory");
+    /// std::fs::create_dir_all(archive)?;
+    /// let file_dir = archive.join("example_deadbeef");
+    /// std::fs::create_dir_all(&file_dir)?;
+    /// std::fs::write(file_dir.join("manifest.json"), b"{}")?;
+    /// let store = FileStore::new(archive)?;
+    /// let manifests = store.as_hashmap()?;
+    /// assert!(!manifests.is_empty());
+    /// std::env::set_current_dir(original)?;
+    /// std::fs::remove_dir_all(sandbox)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn as_hashmap(
         &self,
     ) -> Result<Vec<HashMap<String, HashMap<String, String>>>, std::io::Error> {
@@ -62,6 +111,25 @@ impl FileStore {
         return Ok(file_hashmap);
     }
 
+    /// Placeholder for returning strongly typed manifest models. Invoking the
+    /// function currently performs no work.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::filestore::FileStore;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let sandbox = std::env::temp_dir().join(format!("blockframe_filestore_get_all_{}", std::process::id()));
+    /// if sandbox.exists() {
+    ///     std::fs::remove_dir_all(&sandbox)?;
+    /// }
+    /// std::fs::create_dir_all(&sandbox)?;
+    /// let store = FileStore::new(&sandbox)?;
+    /// store.get_all();
+    /// std::fs::remove_dir_all(store.store_path.clone())?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn get_all(&self) {
         // this is where we fill in our structs and return a vector of our models
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,16 @@ use std::path::Path;
 // use blockframe::chunker::Chunker;
 use blockframe::{chunker::Chunker, filestore::FileStore};
 
+/// Times the execution of a code block, printing the label and elapsed
+/// duration before returning the block's result.
+///
+/// # Examples
+///
+/// ```
+/// # use super::timeit;
+/// let value = timeit!("addition", { 1 + 1 });
+/// assert_eq!(value, 2);
+/// ```
 macro_rules! timeit {
     ($label:expr, $block:block) => {{
         let start = std::time::Instant::now();
@@ -12,6 +22,35 @@ macro_rules! timeit {
     }};
 }
 
+/// Commits two demonstration files, reports the elapsed time for each commit,
+/// and prints a lightweight summary of the archived metadata.
+///
+/// # Examples
+///
+/// ```
+/// # use std::path::Path;
+/// # use blockframe::{chunker::Chunker, filestore::FileStore};
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let sandbox = std::env::temp_dir().join(format!("blockframe_main_demo_{}", std::process::id()));
+/// if sandbox.exists() {
+///     std::fs::remove_dir_all(&sandbox)?;
+/// }
+/// std::fs::create_dir_all(&sandbox)?;
+/// let original = std::env::current_dir()?;
+/// std::env::set_current_dir(&sandbox)?;
+/// std::fs::write("example.txt", b"example data")?;
+/// std::fs::write("big_file.txt", b"big data")?;
+/// let store_path = Path::new("archive_directory");
+/// let store = FileStore::new(store_path)?;
+/// let chunker = Chunker::new()?;
+/// chunker.commit(Path::new("example.txt"))?;
+/// chunker.commit(Path::new("big_file.txt"))?;
+/// assert!(!store.as_hashmap()?.is_empty());
+/// std::env::set_current_dir(&original)?;
+/// std::fs::remove_dir_all(&sandbox)?;
+/// # Ok(())
+/// # }
+/// ```
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // get our file_name
 

--- a/src/merkle_tree/node.rs
+++ b/src/merkle_tree/node.rs
@@ -9,6 +9,16 @@ pub struct Node {
 }
 
 impl fmt::Debug for Node {
+    /// Formats the node by exposing its hash value, which is often the only
+    /// information required when inspecting Merkle trees during debugging.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::merkle_tree::node::Node;
+    /// let node = Node::new("abc123".to_string());
+    /// assert!(format!("{:?}", node).contains("abc123"));
+    /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Node")
             .field("hash", &self.hash_val)
@@ -17,6 +27,17 @@ impl fmt::Debug for Node {
 }
 
 impl Node {
+    /// Creates a leaf node that stores only a hash value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::merkle_tree::node::Node;
+    /// let node = Node::new("deadbeef".to_string());
+    /// assert_eq!(node.hash_val, "deadbeef");
+    /// assert!(node.left.is_none());
+    /// assert!(node.right.is_none());
+    /// ```
     pub fn new(hash_val: String) -> Self {
         Node {
             hash_val,
@@ -24,6 +45,20 @@ impl Node {
             right: None,
         }
     }
+    /// Creates an internal node with the supplied hash and optional child
+    /// pointers, allowing callers to wire custom Merkle tree shapes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use blockframe::merkle_tree::node::Node;
+    /// let left = Node::new("left".into());
+    /// let right = Node::new("right".into());
+    /// let parent = Node::with_children("parent".into(), Some(Box::new(left)), Some(Box::new(right)));
+    /// assert_eq!(parent.hash_val, "parent");
+    /// assert!(parent.left.is_some());
+    /// assert!(parent.right.is_some());
+    /// ```
     pub fn with_children(
         hash_val: String,
         left: Option<Box<Node>>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,24 @@ use blake3::Hasher;
 use std::{fs::File, io, path::Path};
 use sysinfo::System;
 
+/// Computes the BLAKE3 digest of the provided bytes and returns it as a
+/// hexadecimal string.
+///
+/// Although the function is named `sha256`, it currently uses the
+/// [`blake3`](https://docs.rs/blake3) hasher under the hood to produce a
+/// cryptographically secure hash.
+///
+/// # Examples
+///
+/// ```
+/// use blockframe::utils::sha256;
+///
+/// # fn main() -> Result<(), std::io::Error> {
+/// let digest = sha256(b"blockframe")?;
+/// assert_eq!(digest, "c41e3ccb398783c24211ecea54ac84c2029d012165392c9deabbef3a597b8fb7");
+/// # Ok(())
+/// # }
+/// ```
 pub fn sha256(data: &[u8]) -> Result<String, std::io::Error> {
     let mut hasher = Hasher::new();
     hasher.update(data);
@@ -9,6 +27,26 @@ pub fn sha256(data: &[u8]) -> Result<String, std::io::Error> {
     return Ok(result.to_string());
 }
 
+/// Determines the optimal segment size, in bytes, to use when reading a file
+/// into memory.
+///
+/// The function inspects the input file size and the host's available memory
+/// to choose a practical segment length that avoids overwhelming memory-constrained
+/// systems.
+///
+/// # Examples
+///
+/// Small files are kept in a single segment:
+///
+/// ```
+/// use blockframe::utils::determine_segment_size;
+///
+/// # fn main() -> Result<(), std::io::Error> {
+/// let single_segment = determine_segment_size(1024)?;
+/// assert_eq!(single_segment, 1024);
+/// # Ok(())
+/// # }
+/// ```
 pub fn determine_segment_size(file_size: u64) -> Result<usize, std::io::Error> {
     const MIN_SEGMENT: usize = 512 * 1024; // 512KB
     // for small files just read the entire file as one segment
@@ -28,11 +66,48 @@ pub fn determine_segment_size(file_size: u64) -> Result<usize, std::io::Error> {
     }
 }
 
-fn detect_available_memory() -> Result<u64, std::io::Error> {
+/// Returns the amount of free memory reported by the host operating system in
+/// kibibytes.
+///
+/// # Examples
+///
+/// ```
+/// let available = blockframe::utils::detect_available_memory().unwrap();
+/// assert!(available > 0);
+/// ```
+pub fn detect_available_memory() -> Result<u64, std::io::Error> {
     let sys = System::new_all();
     Ok(sys.available_memory())
 }
 
+/// Calculates the BLAKE3 hash of a file by streaming its contents from disk.
+///
+/// The function avoids loading the entire file into memory at once, making it
+/// suitable for hashing large files on systems with limited RAM.
+///
+/// # Examples
+///
+/// ```
+/// use blockframe::utils::{hash_file_streaming, sha256};
+/// use std::fs::File;
+/// use std::io::Write;
+///
+///
+/// # fn main() -> Result<(), std::io::Error> {
+/// let file_path = std::env::temp_dir()
+///     .join(format!("blockframe_hash_{}.txt", std::process::id()));
+///
+/// let mut file = File::create(&file_path)?;
+/// writeln!(file, "hash me")?;
+///
+/// let digest = hash_file_streaming(&file_path)?;
+/// let direct_digest = sha256(&std::fs::read(&file_path)?)?;
+/// assert_eq!(digest, direct_digest);
+///
+/// std::fs::remove_file(file_path)?;
+/// # Ok(())
+/// # }
+/// ```
 pub fn hash_file_streaming(file_path: &Path) -> Result<String, std::io::Error> {
     let mut file = File::open(file_path)?;
     let mut hasher = Hasher::new();


### PR DESCRIPTION
## Summary
- add detailed rustdoc examples for the benchmarking and file generation binaries
- document chunker, filestore, and Merkle tree helpers with runnable doctests
- expose memory detection helper so its documentation can run

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_69006ab57188832a9f00cfda3085246e